### PR TITLE
Refactor: Make the "add_idps" function standalone

### DIFF
--- a/install_local_sp3.sh
+++ b/install_local_sp3.sh
@@ -122,6 +122,8 @@ add_idps(){
 }
 
 register_idps(){
+    check_command_exists "shibd" "Shibboleth-SP" "dependent"
+    
     #Step 1: Add IdPs as <MetadataProvider .../> elements in /etc/shibboleth/shibboleth2.xml file:
     add_idps
     
@@ -139,9 +141,8 @@ register_idps(){
     echo "Testing Shibboleth daemon configuration..."
     sudo shibd -t || { echo "shibd configuration test failed. Check logs."; exit 1; }
 
-    echo -e "\n\033[1;31mInfo: to fully register the IdPs, consider running the following functions in the list."
+    echo -e "\n\033[1;31mInfo: to fully register the IdPs, consider running other functions in the list \"./install_local_sp3.sh <option>\"."
     echo -e "\n\033[1;31mNOTE: \033[0m Add the IdPs domain names with their IPs at the SP's /etc/hosts file and at all your network's /etc/hosts files"
-    ;;
 }
 
 


### PR DESCRIPTION
**What does `add_idps` function do?**
- it reads the the file: `./sp3_supporting_files/idp_list.csv`
- then register each IdP listed on that file in file `/etc/shibboleth/shibboleth2.xml` as `<MetadataProvider .../>` element.
- if the element already existed for specific IdP, it skips it.

**what is the problem**
- previous versions, the function `add_idps()` is set within other functions such as: `configure_shib_sp()`.
- when we add a new IdP in the file `./sp3_supporting_files/idp_list.csv`, then we had to run the function `configure_shib_sp()`.
- every time we run the function `configure_shib_sp()` it generates new `entityID` and the signing keys for the SP. that is what we set it to. It can be changed to static `entityID`, though.
- this is the problem. since the already-registered IdPs has the old metadata for the SP. when re-run the function `configure_shib_sp()`, it generates new `entityID` and the signing keys. which requires the IdPs to update the SP Metadata file once again.

**Solution:**
- follow the concept of KISS (Keep It Simple & Stupid), we extracted the function `add_idps` from the function `configure_shib_sp()`. 
- put it in the option list as `register_idps()`.
- when run `./install_local_sp3.sh`, you will get `register_idps()` among other options.